### PR TITLE
[CORE-1530] adjust-size for fallback fonts to avoid layout shift

### DIFF
--- a/packages/halo/src/tailwind.scss
+++ b/packages/halo/src/tailwind.scss
@@ -90,3 +90,16 @@
   font-style: normal;
   font-display: swap;
 }
+
+// size-adjust fallback fonts to avoid layout shifts
+@font-face {
+  font-family: 'Helvetica Neue';
+  size-adjust: 104.6%;
+  src: local('Helvetica Neue');
+}
+
+@font-face {
+  font-family: 'Arial';
+  size-adjust: 105.5%;
+  src: local('Arial');
+}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -11,6 +11,12 @@ module.exports = {
     'no-invalid-position-at-import-rule': null,
     'number-max-precision': null,
     'property-disallowed-list': ['float'],
+    'property-no-unknown': [
+      true,
+      {
+        ignoreProperties: ['size-adjust'],
+      },
+    ],
     'property-no-vendor-prefix': null,
     'selector-class-pattern': null,
     'shorthand-property-no-redundant-values': null,


### PR DESCRIPTION
We have a lot of complaints from Google about layout shift on our site. I think the main cause is layout shift due to the difference in size between our fallback fonts and brand font. I found some adjust-size values that get pretty close, so that on the initial render text boxes will be sized to fit our brand font too.

I think this property isn't in v14 of stylelint as it is a pretty new addition, so I'm adding the ignore rule rather than go for an upgrade. Hope that is ok :-)

One open question I have is if it would make sense to have these adjustments on the Talent FE side rather than Halo. I figure doing it in Halo gives the same benefit to anything using Halo + the brand font. Would be great to hear what you think.